### PR TITLE
Change baseurl in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For more Hugo details, read [documentation](http://gohugo.io/overview/introducti
 
 Example of config.toml file:
 ```toml
-baseurl = "http://yourSiteHere"
+baseurl = "https://www.example.com"
 languageCode = "fr-fr"
 title = "my new web site"
 [params]

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://gohugo.io"
+baseurl = "https://www.example.com"
 MetaDataFormat = "yaml"
 
 [indexes]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://yourSiteHere"
+baseurl = "https://www.example.com"
 languageCode = "fr-fr"
 title = "my new web site"
 [params]


### PR DESCRIPTION
Avoids the abuse of potential scamming under the default base url. See spf13/hugoThemes#171.

Closes #10
